### PR TITLE
tasks: remove the root of nested children when removing ComplexTask

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,7 +5,8 @@ Exopy Changelog
 0.2.0 - unreleased
 ------------------
 
-Nothing yet
+- fix unproperly unparented child task when removing a ComplexTask PR # 132
+- identify duplicate measurements in the waiting queue PR # 130 (fvalmorra)
 
 
 0.1.0 - 15-02-2018

--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,7 @@ Exopy Changelog
 0.2.0 - unreleased
 ------------------
 
+- always evaluate formula even if they contain only alpha characters PR # 132
 - fix unproperly unparented child task when removing a ComplexTask PR # 132
 - identify duplicate measurements in the waiting queue PR # 130 (fvalmorra)
 

--- a/exopy/instruments/drivers/driver_decl.py
+++ b/exopy/instruments/drivers/driver_decl.py
@@ -56,7 +56,7 @@ class Driver(Declarator):
     #: Supported connections and default values for some parameters. The
     #: admissible values for a given kind can be determined by looking at the
     #: Connection object whose id match.
-    #: ex : {'visa_tcpip' : {'port': 7500, 'resource_class': 'SOCKET'}}
+    #: ex : {'VisaTCPIP' : {'port': 7500, 'resource_class': 'SOCKET'}}
     #: Can be inferred from parent Drivers.
     connections = d_(Dict())
 

--- a/exopy/instruments/starters/base_starter.py
+++ b/exopy/instruments/starters/base_starter.py
@@ -108,5 +108,5 @@ class Starter(Declarative):
 
     #: Starter instance to use for managing associate instruments.
     #: Note that the class must be defined in a python file not enaml file
-    #:  to be pickeable.
+    #: to be pickeable.
     starter = d_(Typed(BaseStarter))

--- a/exopy/tasks/tasks/base_tasks.py
+++ b/exopy/tasks/tasks/base_tasks.py
@@ -987,7 +987,7 @@ class ComplexTask(BaseTask):
         """Handle the task being renamed at runtime.
 
         If the task is renamed at runtime, it means that the path of all the
-        children task is now obselete and that the database node
+        children task is now obsolete and that the database node
         of this task must be renamed (database handles the exception.
 
         """
@@ -995,6 +995,17 @@ class ComplexTask(BaseTask):
             super(ComplexTask, self)._post_setattr_name(old, new)
             self.database.rename_node(self.path, old, new)
 
+            # Update the path of all children.
+            self._update_children_path()
+
+    def _post_setattr_path(self, old, new):
+        """Handle the task path being modified at runtime..
+
+        If the path of the task is changed at runtime, it means that the path
+        of all the children task is now obsolete.
+
+        """
+        if old and self.database:
             # Update the path of all children.
             self._update_children_path()
 

--- a/exopy/tasks/tasks/logic/loop_task.py
+++ b/exopy/tasks/tasks/logic/loop_task.py
@@ -180,7 +180,7 @@ class LoopTask(InterfaceableTaskMixin, ComplexTask):
 
         """
         if old:
-            if self.has_root:
+            if self.root is not None:
                 old.unregister_from_database()
                 old.root = None
                 old.parent = None
@@ -188,7 +188,7 @@ class LoopTask(InterfaceableTaskMixin, ComplexTask):
         if new:
             new.name = self.name
 
-            if self.has_root:
+            if self.root is not None:
                 new.depth = self.depth + 1
                 new.database = self.database
                 new.path = self._child_path()
@@ -211,7 +211,7 @@ class LoopTask(InterfaceableTaskMixin, ComplexTask):
             aux['value'] = 1.0
             self.database_entries = aux
 
-        if self.has_root:
+        if self.root is not None:
             self.register_preferences()
 
     def _post_setattr_timing(self, old, new):

--- a/exopy/tasks/tasks/string_evaluation.py
+++ b/exopy/tasks/tasks/string_evaluation.py
@@ -42,10 +42,7 @@ EVALUATER_TOOLTIP = '\n'.join([
 
 
 def safe_eval(expr, local_var):
-    """Eval expr save is expr contains only letters.
+    """Eval expr with the given local variables.
 
     """
-    if expr.isalpha():
-        return expr
-
     return eval(expr, globals(), local_var)

--- a/tests/tasks/tasks/logic/test_conditional_task.py
+++ b/tests/tasks/tasks/logic/test_conditional_task.py
@@ -75,6 +75,16 @@ class TestConditionTask(object):
         self.task.perform()
         assert not self.check.perform_called
 
+    def test_perform3(self):
+        """Test performing when condition is False.
+
+        """
+        self.task.condition = 'False'
+        self.root.prepare()
+
+        self.task.perform()
+        assert not self.check.perform_called
+
 
 @pytest.mark.ui
 def test_view(exopy_qtbot):

--- a/tests/tasks/tasks/test_base_tasks.py
+++ b/tests/tasks/tasks/test_base_tasks.py
@@ -199,6 +199,9 @@ def test_deleting_child():
 
     task1.remove_child_task(0)
 
+    assert task2.parent is None
+    assert task2.root is None
+    assert task2.database is None
     assert listener.counter == 1
     assert listener.signals[0].removed
 
@@ -207,6 +210,11 @@ def test_deleting_child():
 
     root.remove_child_task(0)
 
+    assert task1.parent is None
+    assert task1.root is None
+    assert task1.database is None
+    assert task4.root is None
+    assert task4.database is None
     assert len(root.children) == 1
     with pytest.raises(KeyError):
         root.get_from_database('task1_val1')

--- a/tests/tasks/tasks/test_base_tasks.py
+++ b/tests/tasks/tasks/test_base_tasks.py
@@ -220,6 +220,37 @@ def test_deleting_child():
         root.get_from_database('task1_val1')
 
 
+def test_moving_through_remove_add_child():
+    """Test moving a child between different tasks through remove/add.
+
+    """
+    root = RootTask()
+    task1 = ComplexTask(name='task1',
+                        database_entries={'val1': 2.0})
+    task2 = ComplexTask(name='task2',
+                        database_entries={'val2': 2.0})
+    task3 = SimpleTask(name='task3',
+                       database_entries={'val3': 1},
+                       access_exs={'val3': 2})
+
+    task2.add_child_task(0, task3)
+    task1.add_child_task(1, task2)
+    root.add_child_task(0, task1)
+
+    task1.remove_child_task(0)
+
+    assert task2.parent is None
+    assert task2.root is None
+    assert task2.database is None
+    assert task3.parent is not None
+    assert task3.root is None
+    assert task3.database is None
+
+    root.add_child_task(0, task2)
+
+    assert len(root.children) == 2
+
+
 def test_task_renaming():
     """Test renaming simple and complex task.
 

--- a/tests/tasks/tasks/test_string_ops.py
+++ b/tests/tasks/tasks/test_string_ops.py
@@ -156,14 +156,6 @@ class TestEvaluation(object):
         database.set_value('root/node1', 'val2', 10.0)
         database.add_access_exception('root', 'root/node1', 'val2')
 
-    def test_eval_pure_string_editing_mode(self):
-        """Test evaluating a word.
-
-        """
-        test = 'test'
-        formatted = self.root.format_and_eval_string(test)
-        assert formatted == 'test'
-
     def test_eval_editing_mode1(self):
         """Test eval expression with only standard operators.
 
@@ -201,15 +193,6 @@ class TestEvaluation(object):
         formatted = self.root.format_and_eval_string(test)
         assert_array_equal(formatted, numpy.array((1.0, 1.0)))
         assert not self.root._eval_cache
-
-    def test_eval_pure_string_running_mode(self):
-        """Test evaluating a word.
-
-        """
-        self.root.database.prepare_to_run()
-        test = 'test'
-        formatted = self.root.format_and_eval_string(test)
-        assert formatted == 'test'
 
     def test_eval_running_mode1(self):
         """Test eval expression with only standard operators.

--- a/tests/tasks/tasks/util/test_definition_task.py
+++ b/tests/tasks/tasks/util/test_definition_task.py
@@ -41,7 +41,7 @@ class TestDefinitionTask(object):
         """
         self.task.write_in_database('it', 'World')
         self.task.definitions = OrderedDict([('key1', "2.0+3.0"),
-                                             ('key2', 'Hello')])
+                                             ('key2', '"Hello"')])
         self.root.prepare()
 
         self.task.check()
@@ -56,7 +56,7 @@ class TestDefinitionTask(object):
         """
         self.task.write_in_database('it', 'World')
 
-        pref = "[(u'key1', u'1.0+3.0'), (u'key2', u'Hello')]"
+        pref = """[(u'key1', u'1.0+3.0'), (u'key2', u'"Hello"')]"""
         self.task.definitions = ordered_dict_from_pref(self,
                                                        self.task.definitions,
                                                        pref)


### PR DESCRIPTION
Closes #131 

~~When moving a ComplexTask with nested ComplexTask we need to properly update their path (database path) as otherwise they reference non existent nodes.~~
The real issue was that the children were not removed the reference to the root task. This is now fixed and tested. A review would be nice @Exopy/owners . And I will use this to make a mini tutorial on traceback reading on Friday.