### PR TITLE
Fix #112: add 'meas_time' to the database

### DIFF
--- a/exopy/measurement/measurement.py
+++ b/exopy/measurement/measurement.py
@@ -632,7 +632,7 @@ class Measurement(HasPrefAtom):
         self.root_task.write_in_database('meas_id', self.id)
         self.root_task.write_in_database('meas_date', str(date.today()))
         self.root_task.write_in_database('meas_time', datetime.now().time()
-                                         .isoformat(timespec='seconds'))
+                                         .strftime("%H:%M:%S"))
 
     def _post_setattr_root_task(self, old, new):
         """Add the entries contributed by the measurement to the task database.

--- a/exopy/measurement/measurement.py
+++ b/exopy/measurement/measurement.py
@@ -632,7 +632,7 @@ class Measurement(HasPrefAtom):
         self.root_task.write_in_database('meas_id', self.id)
         self.root_task.write_in_database('meas_date', str(date.today()))
         self.root_task.write_in_database('meas_time', datetime.now().time()
-                                         .strftime("%H:%M:%S"))
+                                         .strftime("%H-%M-%S"))
 
     def _post_setattr_root_task(self, old, new):
         """Add the entries contributed by the measurement to the task database.

--- a/exopy/measurement/measurement.py
+++ b/exopy/measurement/measurement.py
@@ -13,7 +13,7 @@
 import logging
 from collections import OrderedDict, defaultdict
 from itertools import chain
-from datetime import date
+from datetime import date, datetime
 
 from atom.api import (Atom, Dict, Unicode, Typed, ForwardTyped, Bool, Enum,
                       Value)
@@ -631,6 +631,8 @@ class Measurement(HasPrefAtom):
         self.root_task.write_in_database('meas_name', self.name)
         self.root_task.write_in_database('meas_id', self.id)
         self.root_task.write_in_database('meas_date', str(date.today()))
+        self.root_task.write_in_database('meas_time', datetime.now().time()
+                                         .isoformat(timespec='seconds'))
 
     def _post_setattr_root_task(self, old, new):
         """Add the entries contributed by the measurement to the task database.
@@ -638,7 +640,7 @@ class Measurement(HasPrefAtom):
         """
         entries = new.database_entries.copy()
         entries.update({'meas_name': self.name, 'meas_id': self.id,
-                        'meas_date': ''})
+                        'meas_date': '', 'meas_time': ''})
         new.database_entries = entries
 
     def _default_dependencies(self):

--- a/tests/measurement/test_measurement.py
+++ b/tests/measurement/test_measurement.py
@@ -75,7 +75,7 @@ def test_measurement_persistence(measurement_workbench, measurement, tmpdir,
     measurement_workbench.register(TasksManagerManifest())
     plugin = measurement_workbench.get_plugin('exopy.measurement')
 
-    for m_e in ('meas_name', 'meas_id', 'meas_date'):
+    for m_e in ('meas_name', 'meas_id', 'meas_date', 'meas_time'):
         assert m_e in measurement.root_task.database_entries
     measurement.add_tool('pre-hook', 'dummy')
     measurement.root_task.default_path = 'test'


### PR DESCRIPTION
'meas_time' is the current time with a one second resolution.