### PR TITLE
Fix #14

### DIFF
--- a/exopy/measurement/workspace/measurement_edition.enaml
+++ b/exopy/measurement/workspace/measurement_edition.enaml
@@ -111,7 +111,7 @@ enamldef TaskPasteAction(Action):
         widget._append(node, obj, new_data, False)
 
 
-def build_task(workbench, root):
+def build_task(workbench, future_parent):
     """Call the Command responsible for building a task.
 
     """
@@ -119,7 +119,7 @@ def build_task(workbench, root):
     ui = workbench.get_plugin('enaml.workbench.ui')
     return core.invoke_command('exopy.tasks.create_task',
                                {'parent_ui': ui.window,
-                                'root': root})
+                                'future_parent': future_parent})
 
 
 enamldef SimpleMenu(Menu): menu:
@@ -136,12 +136,12 @@ enamldef SimpleMenu(Menu): menu:
         action_context << context
         factory = build_task
         mode = 'Add before'
-        kwargs = {'workbench': workspace.workbench, 'root': context['data'][2].root}
+        kwargs = {'workbench': workspace.workbench, 'future_parent': context['data'][2]}
     NewAction:
         action_context << context
         factory = build_task
         mode = 'Add after'
-        kwargs = {'workbench': workspace.workbench, 'root': context['data'][2].root}
+        kwargs = {'workbench': workspace.workbench, 'future_parent': context['data'][2]}
 
     Action:
         separator = True
@@ -180,17 +180,17 @@ enamldef ComplexMenu(Menu): menu:
     NewAction:
         action_context << context
         factory = build_task
-        kwargs = {'workbench': workspace.workbench, 'root': context['data'][2].root}
+        kwargs = {'workbench': workspace.workbench, 'future_parent': context['data'][2]}
     NewAction:
         action_context << context
         factory = build_task
         mode = 'Add before'
-        kwargs = {'workbench': workspace.workbench, 'root': context['data'][2].root}
+        kwargs = {'workbench': workspace.workbench, 'future_parent': context['data'][2]}
     NewAction:
         action_context << context
         factory = build_task
         mode = 'Add after'
-        kwargs = {'workbench': workspace.workbench, 'root': context['data'][2].root}
+        kwargs = {'workbench': workspace.workbench, 'future_parent': context['data'][2]}
 
     Action:
         separator = True

--- a/exopy/measurement/workspace/measurement_edition.enaml
+++ b/exopy/measurement/workspace/measurement_edition.enaml
@@ -210,6 +210,10 @@ enamldef TaskTreeNode(TreeNode):
         return obj.name + '(' + obj.task_id + ')'
     enter_rename => (obj):
         return obj.name
+    exit_rename => (obj, label):
+        forbidden_names = obj.root.get_used_names()
+        if label not in forbidden_names:
+            obj.name = label
 
 
 class _MeasEditionModel(Atom):

--- a/exopy/measurement/workspace/measurement_edition.enaml
+++ b/exopy/measurement/workspace/measurement_edition.enaml
@@ -90,14 +90,15 @@ enamldef TaskCopyAction(Action):
         CLIPBOARD.instance = copy
 
 
-def build_task(workbench):
+def build_task(workbench, root):
     """Call the Command responsible for building a task.
 
     """
     core = workbench.get_plugin('enaml.workbench.core')
     ui = workbench.get_plugin('enaml.workbench.ui')
     return core.invoke_command('exopy.tasks.create_task',
-                               {'parent_ui': ui.window})
+                               {'parent_ui': ui.window,
+                                'root': root})
 
 
 enamldef SimpleMenu(Menu): menu:
@@ -114,12 +115,12 @@ enamldef SimpleMenu(Menu): menu:
         action_context << context
         factory = build_task
         mode = 'Add before'
-        kwargs = {'workbench': workspace.workbench}
+        kwargs = {'workbench': workspace.workbench, 'root': context['data'][2].root}
     NewAction:
         action_context << context
         factory = build_task
         mode = 'Add after'
-        kwargs = {'workbench': workspace.workbench}
+        kwargs = {'workbench': workspace.workbench, 'root': context['data'][2].root}
 
     Action:
         separator = True
@@ -158,17 +159,17 @@ enamldef ComplexMenu(Menu): menu:
     NewAction:
         action_context << context
         factory = build_task
-        kwargs = {'workbench': workspace.workbench}
+        kwargs = {'workbench': workspace.workbench, 'root': context['data'][2].root}
     NewAction:
         action_context << context
         factory = build_task
         mode = 'Add before'
-        kwargs = {'workbench': workspace.workbench}
+        kwargs = {'workbench': workspace.workbench, 'root': context['data'][2].root}
     NewAction:
         action_context << context
         factory = build_task
         mode = 'Add after'
-        kwargs = {'workbench': workspace.workbench}
+        kwargs = {'workbench': workspace.workbench, 'root': context['data'][2].root}
 
     Action:
         separator = True

--- a/exopy/measurement/workspace/measurement_edition.enaml
+++ b/exopy/measurement/workspace/measurement_edition.enaml
@@ -26,7 +26,7 @@ from ...utils.widgets.qt_clipboard import CLIPBOARD
 from ...utils.widgets.qt_tree_widget import QtTreeWidget
 from ...utils.widgets.tree_nodes import TreeNode
 from ...utils.widgets.qt_tree_menu import \
-    (CutAction, PasteAction, NewAction, RenameAction, DeleteAction)
+    (CutAction, NewAction, RenameAction, DeleteAction)
 from ...tasks.api import (BaseTask, SimpleTask, ComplexTask)
 from ...tasks.utils.building import build_task_from_config
 from ..editors.base_editor import BaseEditor
@@ -90,6 +90,27 @@ enamldef TaskCopyAction(Action):
         CLIPBOARD.instance = copy
 
 
+enamldef TaskPasteAction(Action):
+    """ Pastes the task currently in the paste buffer into the current node.
+
+    """
+    #: Context holding the informations about on which task this action was
+    #: invoked. See exopy.utils.widgets.tree_node for a more complete
+    #: description.
+    attr action_context
+
+    text = 'Paste'
+    visible << action_context['pasteable']
+    triggered::
+        widget, node, obj, nid = action_context['data']
+        new_data = CLIPBOARD.instance
+        used_names = obj.root.get_used_names()
+        for i in new_data.traverse():
+            if hasattr(i, 'name') and i.name in used_names:
+                i.name = "(copy)" + i.name
+        widget._append(node, obj, new_data, False)
+
+
 def build_task(workbench, root):
     """Call the Command responsible for building a task.
 
@@ -130,7 +151,7 @@ enamldef SimpleMenu(Menu): menu:
     TaskCopyAction:
         workspace = menu.workspace
         action_context << context
-    PasteAction:
+    TaskPasteAction:
         action_context << context
 
     Action:
@@ -186,7 +207,7 @@ enamldef ComplexMenu(Menu): menu:
     TaskCopyAction:
         workspace = menu.workspace
         action_context << context
-    PasteAction:
+    TaskPasteAction:
         action_context << context
 
     Action:

--- a/exopy/tasks/configs/base_config_views.enaml
+++ b/exopy/tasks/configs/base_config_views.enaml
@@ -13,6 +13,7 @@ from enaml.core.api import Conditional
 from enaml.layout.api import hbox, vbox, spacer
 from enaml.widgets.api import (Container, MultilineField, Field, GroupBox,
                                Label)
+from enaml.colors import parse_color
 
 
 enamldef BaseConfigView(Container):
@@ -34,6 +35,7 @@ enamldef BaseConfigView(Container):
     Field: t_f:
         text := config.task_name
         submit_triggers = ['lost_focus', 'return_pressed', 'auto_sync']
+        background << parse_color("#FFFFFF") if config.name_valid else parse_color("#FF000030")
 
 
 enamldef PyConfigView(BaseConfigView): main:

--- a/exopy/tasks/configs/base_configs.py
+++ b/exopy/tasks/configs/base_configs.py
@@ -15,7 +15,7 @@ from atom.api import (Atom, Bool, Unicode, Subclass, ForwardTyped, Typed)
 
 from inspect import getdoc
 
-from ..tasks.base_tasks import (BaseTask, RootTask)
+from ..tasks.base_tasks import BaseTask
 from ..utils.templates import load_template
 from ..utils.building import build_task_from_config
 

--- a/exopy/tasks/configs/base_configs.py
+++ b/exopy/tasks/configs/base_configs.py
@@ -81,7 +81,10 @@ class BaseTaskConfig(Atom):
     def _default_task_name(self):
         names = self.manager.auto_task_names
         if names:
-            return random.choice(names)
+            name = random.choice(names)
+            if name not in self.root.get_used_names():
+                self.ready = True
+            return name
         else:
             return ''
 

--- a/exopy/tasks/configs/base_configs.py
+++ b/exopy/tasks/configs/base_configs.py
@@ -15,7 +15,6 @@ from atom.api import (Atom, Bool, Unicode, Subclass, ForwardTyped, Typed)
 
 from inspect import getdoc
 
-from ..tasks.task_interface import TaskInterface
 from ..tasks.base_tasks import (BaseTask, RootTask)
 from ..utils.templates import load_template
 from ..utils.building import build_task_from_config
@@ -56,7 +55,9 @@ class BaseTaskConfig(Atom):
         """The only parameter required is a unique task name.
 
         """
-        names = self._used_names()
+        names = []
+        if self.root:
+            names = self.root.get_used_names()
         self.ready = self.task_name != "" and self.task_name not in names
 
     def build_task(self):
@@ -83,14 +84,6 @@ class BaseTaskConfig(Atom):
             return random.choice(names)
         else:
             return ''
-
-    def _used_names(self):
-        names = []
-        if self.root:
-            for i in self.root.traverse():
-                if not isinstance(i, TaskInterface):
-                    names.append(i.name)
-        return names
 
 
 class PyTaskConfig(BaseTaskConfig):

--- a/exopy/tasks/configs/base_configs.py
+++ b/exopy/tasks/configs/base_configs.py
@@ -59,6 +59,10 @@ class BaseTaskConfig(Atom):
         """The only parameter required is a unique task name.
 
         """
+        # Checking the parameters make sense only if the manager is known
+        if not self.manager:
+            return
+        
         names = []
         if self.future_parent:
             names = self.future_parent.root.get_used_names()

--- a/exopy/tasks/configs/base_configs.py
+++ b/exopy/tasks/configs/base_configs.py
@@ -90,8 +90,6 @@ class BaseTaskConfig(Atom):
             for i in self.root.traverse():
                 if not isinstance(i, TaskInterface):
                     names.append(i.name)
-                else:
-                    names.append(i.task.name)
         return names
 
 

--- a/exopy/tasks/configs/base_configs.py
+++ b/exopy/tasks/configs/base_configs.py
@@ -53,6 +53,8 @@ class BaseTaskConfig(Atom):
 
     def __init__(self, **kwargs):
         super(BaseTaskConfig, self).__init__(**kwargs)
+        # Force check to ensure that the possible default value of task_name
+        # is tested.
         self.check_parameters()
 
     def check_parameters(self):
@@ -62,7 +64,7 @@ class BaseTaskConfig(Atom):
         # Checking the parameters make sense only if the manager is known
         if not self.manager:
             return
-        
+
         names = []
         if self.future_parent:
             names = self.future_parent.root.get_used_names()

--- a/exopy/tasks/configs/loop_config.py
+++ b/exopy/tasks/configs/loop_config.py
@@ -13,6 +13,7 @@ from atom.api import (Typed, Unicode, Bool)
 
 from .base_configs import PyTaskConfig, BaseTaskConfig
 from .base_config_views import BaseConfigView
+from ..tasks.task_interface import TaskInterface
 
 
 class LoopTaskConfig(PyTaskConfig):
@@ -35,7 +36,8 @@ class LoopTaskConfig(PyTaskConfig):
         """Ensure that both this config and the subconfig parameters are valid.
 
         """
-        if self.task_name != '':
+        names = self._used_names()
+        if self.task_name != '' and self.task_name not in names:
             if self.use_subtask:
                 if self.subconfig is not None:
                     self.subconfig.task_name = self.task_name

--- a/exopy/tasks/configs/loop_config.py
+++ b/exopy/tasks/configs/loop_config.py
@@ -36,9 +36,10 @@ class LoopTaskConfig(PyTaskConfig):
 
         """
         names = []
-        if self.root:
-            names = self.root.get_used_names()
-        if self.task_name != '' and self.task_name not in names:
+        if self.future_parent:
+            names = self.future_parent.root.get_used_names()
+        self.name_valid = self.task_name != '' and self.task_name not in names
+        if self.name_valid:
             if self.use_subtask:
                 if self.subconfig is not None:
                     self.subconfig.task_name = self.task_name

--- a/exopy/tasks/configs/loop_config.py
+++ b/exopy/tasks/configs/loop_config.py
@@ -38,7 +38,7 @@ class LoopTaskConfig(PyTaskConfig):
         # Run the checks only if the manager is known.
         if not self.manager:
             return
-        
+
         names = []
         if self.future_parent:
             names = self.future_parent.root.get_used_names()

--- a/exopy/tasks/configs/loop_config.py
+++ b/exopy/tasks/configs/loop_config.py
@@ -13,7 +13,6 @@ from atom.api import (Typed, Unicode, Bool)
 
 from .base_configs import PyTaskConfig, BaseTaskConfig
 from .base_config_views import BaseConfigView
-from ..tasks.task_interface import TaskInterface
 
 
 class LoopTaskConfig(PyTaskConfig):
@@ -36,7 +35,9 @@ class LoopTaskConfig(PyTaskConfig):
         """Ensure that both this config and the subconfig parameters are valid.
 
         """
-        names = self._used_names()
+        names = []
+        if self.root:
+            names = self.root.get_used_names()
         if self.task_name != '' and self.task_name not in names:
             if self.use_subtask:
                 if self.subconfig is not None:

--- a/exopy/tasks/configs/loop_config.py
+++ b/exopy/tasks/configs/loop_config.py
@@ -35,6 +35,10 @@ class LoopTaskConfig(PyTaskConfig):
         """Ensure that both this config and the subconfig parameters are valid.
 
         """
+        # Run the checks only if the manager is known.
+        if not self.manager:
+            return
+        
         names = []
         if self.future_parent:
             names = self.future_parent.root.get_used_names()

--- a/exopy/tasks/manifest.enaml
+++ b/exopy/tasks/manifest.enaml
@@ -269,8 +269,8 @@ Parameters:
 parent_ui : optional
     Optional parent widget for the dialog.
 
-root : RootTask
-    Root task of the tree in which a new task will be inserted.
+future_parent : BaseTask
+    Future parent task of the new task will be inserted.
 
 Returns:
 -------

--- a/exopy/tasks/manifest.enaml
+++ b/exopy/tasks/manifest.enaml
@@ -269,6 +269,9 @@ Parameters:
 parent_ui : optional
     Optional parent widget for the dialog.
 
+root : RootTask
+    Root task of the tree in which a new task will be inserted.
+
 Returns:
 -------
 task : BaseTask

--- a/exopy/tasks/tasks/base_tasks.py
+++ b/exopy/tasks/tasks/base_tasks.py
@@ -1226,6 +1226,21 @@ class RootTask(ComplexTask):
         task.register_preferences()
         return task
 
+    def get_used_names(self):
+        """Return the list of all names used in the tree
+        Returns
+        -------
+        names : List(str)
+            List of all the names used in the tree.
+
+        """
+        names = []
+        for i in self.traverse():
+            # Effectively ignores TaskInterface objects
+            if hasattr(i, 'name'):
+                names.append(i.name)
+        return names
+
     # =========================================================================
     # --- Private API ---------------------------------------------------------
     # =========================================================================

--- a/exopy/tasks/tasks/base_views.enaml
+++ b/exopy/tasks/tasks/base_views.enaml
@@ -88,13 +88,11 @@ enamldef RootTaskView(BaseTaskView): main:
         BaseTaskView.refresh(self)
         editor.refresh()
 
-    # TODO pass the future parent task so that config can do name inspections
-    # and avoid duplicate names.
     func create_new_task():
         """Create a new task to insert into the hierarchy.
 
         """
-        return core.invoke_command('exopy.tasks.create_task', dict(widget=self))
+        return core.invoke_command('exopy.tasks.create_task', dict(widget=self, root=self.task))
 
     func get_interfaces_for(obj):
         """Get the available interfaces for a given object.

--- a/exopy/tasks/tasks/base_views.enaml
+++ b/exopy/tasks/tasks/base_views.enaml
@@ -88,11 +88,16 @@ enamldef RootTaskView(BaseTaskView): main:
         BaseTaskView.refresh(self)
         editor.refresh()
 
-    func create_new_task():
+    func create_new_task(future_parent):
         """Create a new task to insert into the hierarchy.
 
+        Parameters
+        ----------
+        future_parent:
+            Future parent of the task
+
         """
-        return core.invoke_command('exopy.tasks.create_task', dict(parent_ui=self, root=self.task))
+        return core.invoke_command('exopy.tasks.create_task', dict(parent_ui=self, future_parent=future_parent))
 
     func get_interfaces_for(obj):
         """Get the available interfaces for a given object.

--- a/exopy/tasks/tasks/base_views.enaml
+++ b/exopy/tasks/tasks/base_views.enaml
@@ -92,7 +92,7 @@ enamldef RootTaskView(BaseTaskView): main:
         """Create a new task to insert into the hierarchy.
 
         """
-        return core.invoke_command('exopy.tasks.create_task', dict(widget=self, root=self.task))
+        return core.invoke_command('exopy.tasks.create_task', dict(parent_ui=self, root=self.task))
 
     func get_interfaces_for(obj):
         """Get the available interfaces for a given object.

--- a/exopy/tasks/tasks/task_editor.enaml
+++ b/exopy/tasks/tasks/task_editor.enaml
@@ -60,7 +60,7 @@ enamldef EmptyEditorButton(PushButton):
     text = 'Add a first task'
 
     clicked ::
-        task = editor.root.create_new_task()
+        task = editor.root.create_new_task(editor.task)
         if task:
             editor.task.add_child_task(0, task)
 
@@ -245,7 +245,7 @@ class TaskEditor(Container):
             """Handler for the add entry of the menu.
 
             """
-            task = self.root.create_new_task()
+            task = self.root.create_new_task(self.task)
             if task:
                 if position == 'after':
                     index += 1

--- a/exopy/tasks/utils/building.py
+++ b/exopy/tasks/utils/building.py
@@ -37,7 +37,8 @@ def create_task(event):
     """
     manager = event.workbench.get_plugin('exopy.tasks')
     dialog = BuilderView(manager=manager,
-                         parent=event.parameters.get('widget'))
+                         parent=event.parameters.get('widget'),
+                         root=event.parameters.get('root'))
     result = dialog.exec_()
     if result:
         return dialog.config.build_task()

--- a/exopy/tasks/utils/building.py
+++ b/exopy/tasks/utils/building.py
@@ -29,8 +29,8 @@ def create_task(event):
     parent_ui : optional
         Optional parent widget for the dialog.
 
-    root : RootTask
-        Root task of the tree in which a new task will be inserted.
+    future_parent : BaseTask
+        Future parent of the task
 
     Returns:
     -------
@@ -41,7 +41,7 @@ def create_task(event):
     manager = event.workbench.get_plugin('exopy.tasks')
     dialog = BuilderView(manager=manager,
                          parent=event.parameters.get('parent_ui'),
-                         root=event.parameters.get('root'))
+                         future_parent=event.parameters.get('future_parent'))
     result = dialog.exec_()
     if result:
         return dialog.config.build_task()

--- a/exopy/tasks/utils/building.py
+++ b/exopy/tasks/utils/building.py
@@ -26,8 +26,11 @@ def create_task(event):
 
     Parameters
     ----------
-    widget : optional
+    parent_ui : optional
         Optional parent widget for the dialog.
+
+    root : RootTask
+        Root task of the tree in which a new task will be inserted.
 
     Returns:
     -------
@@ -37,7 +40,7 @@ def create_task(event):
     """
     manager = event.workbench.get_plugin('exopy.tasks')
     dialog = BuilderView(manager=manager,
-                         parent=event.parameters.get('widget'),
+                         parent=event.parameters.get('parent_ui'),
                          root=event.parameters.get('root'))
     result = dialog.exec_()
     if result:

--- a/exopy/tasks/widgets/building.enaml
+++ b/exopy/tasks/widgets/building.enaml
@@ -38,7 +38,8 @@ enamldef BuilderView(Dialog): dial:
     #: Reference to the task manager.
     alias manager : selector.manager
 
-    attr root
+    #: Future parent of the task
+    attr future_parent
 
     #: Config object corresponding to the currently selected task.
     attr config
@@ -54,7 +55,7 @@ enamldef BuilderView(Dialog): dial:
             if config is None:
                 dial.config = None
                 return [Label(text='No config found for this task.')]
-            config.root = root
+            config.future_parent = future_parent
             dial.config = config
             return [view]
         else:

--- a/exopy/tasks/widgets/building.enaml
+++ b/exopy/tasks/widgets/building.enaml
@@ -38,6 +38,8 @@ enamldef BuilderView(Dialog): dial:
     #: Reference to the task manager.
     alias manager : selector.manager
 
+    attr root
+
     #: Config object corresponding to the currently selected task.
     attr config
 
@@ -52,6 +54,7 @@ enamldef BuilderView(Dialog): dial:
             if config is None:
                 dial.config = None
                 return [Label(text='No config found for this task.')]
+            config.root = root
             dial.config = config
             return [view]
         else:

--- a/exopy/utils/widgets/qt_tree_widget.py
+++ b/exopy/utils/widgets/qt_tree_widget.py
@@ -783,8 +783,7 @@ class QtTreeWidget(RawWidget):
         if new_label != old_label:
             if new_label != '':
                 node.exit_rename(obj, new_label)
-            else:
-                self._set_label(nid, old_label)
+            self._set_label(nid, node.get_label(obj))
 
     def _children_replaced(self, change):
         """ Handles the children of a node being completely replaced.

--- a/exopy/utils/widgets/tree_nodes.py
+++ b/exopy/utils/widgets/tree_nodes.py
@@ -177,10 +177,7 @@ class TreeNode(Declarative):
 
         """
         label_name = self.label
-        forbidden_names = []
-        if hasattr(obj, 'root') and obj.root:
-            forbidden_names = obj.root.get_used_names()
-        if label_name[:1] != '=' and label not in forbidden_names:
+        if label_name[:1] != '=':
             setattr(obj, label_name, label)
 
     @d_func

--- a/exopy/utils/widgets/tree_nodes.py
+++ b/exopy/utils/widgets/tree_nodes.py
@@ -177,7 +177,10 @@ class TreeNode(Declarative):
 
         """
         label_name = self.label
-        if label_name[:1] != '=':
+        forbidden_names = []
+        if hasattr(obj, 'root') and obj.root:
+            forbidden_names = obj.root.get_used_names()
+        if label_name[:1] != '=' and label not in forbidden_names:
             setattr(obj, label_name, label)
 
     @d_func

--- a/tests/tasks/configs/test_base_configs.py
+++ b/tests/tasks/configs/test_base_configs.py
@@ -33,7 +33,7 @@ def test_py_task_config(exopy_qtbot, task_workbench):
     root = RootTask()
     config = PyTaskConfig(manager=plugin,
                           task_class=plugin.get_task('exopy.ComplexTask'),
-                          root=root)
+                          future_parent=root)
 
     assert config.task_name
     assert config.ready
@@ -50,7 +50,7 @@ def test_py_task_config(exopy_qtbot, task_workbench):
     root.add_child_task(0, task)
     config2 = PyTaskConfig(manager=plugin,
                            task_class=plugin.get_task('exopy.ComplexTask'),
-                           root=root)
+                           future_parent=root)
 
     config2.task_name = 'Test'
     assert not config2.ready
@@ -61,7 +61,7 @@ def test_py_task_config(exopy_qtbot, task_workbench):
     plugin.auto_task_names = []
     config = PyTaskConfig(manager=plugin,
                           task_class=plugin.get_task('exopy.ComplexTask'),
-                          root=root)
+                          future_parent=root)
 
     assert not config.task_name
     assert not config.ready
@@ -82,7 +82,7 @@ def test_template_task_config(exopy_qtbot, task_workbench):
     root = RootTask()
     config = TemplateTaskConfig(manager=plugin,
                                 template_path=path,
-                                root=root)
+                                future_parent=root)
     assert config.template_doc
     task = config.build_task()
     assert len(task.children) == 1

--- a/tests/tasks/configs/test_base_configs.py
+++ b/tests/tasks/configs/test_base_configs.py
@@ -15,6 +15,7 @@ import pytest
 import enaml
 
 from exopy.testing.util import show_and_close_widget
+from exopy.tasks.tasks.base_tasks import RootTask
 from exopy.tasks.configs.base_configs import (PyTaskConfig,
                                               TemplateTaskConfig)
 with enaml.imports():
@@ -29,8 +30,10 @@ def test_py_task_config(exopy_qtbot, task_workbench):
     """
     plugin = task_workbench.get_plugin('exopy.tasks')
 
+    root = RootTask()
     config = PyTaskConfig(manager=plugin,
-                          task_class=plugin.get_task('exopy.ComplexTask'))
+                          task_class=plugin.get_task('exopy.ComplexTask'),
+                          root=root)
 
     assert config.task_name
     assert config.ready
@@ -40,12 +43,25 @@ def test_py_task_config(exopy_qtbot, task_workbench):
     assert not config.ready
 
     config.task_name = 'Test'
+    assert config.ready
     task = config.build_task()
     assert task.name == 'Test'
 
+    root.add_child_task(0, task)
+    config2 = PyTaskConfig(manager=plugin,
+                           task_class=plugin.get_task('exopy.ComplexTask'),
+                           root=root)
+
+    config2.task_name = 'Test'
+    assert not config2.ready
+
+    config2.task_name = 'ADifferentName'
+    assert config2.ready
+
     plugin.auto_task_names = []
     config = PyTaskConfig(manager=plugin,
-                          task_class=plugin.get_task('exopy.ComplexTask'))
+                          task_class=plugin.get_task('exopy.ComplexTask'),
+                          root=root)
 
     assert not config.task_name
     assert not config.ready
@@ -63,8 +79,10 @@ def test_template_task_config(exopy_qtbot, task_workbench):
 
     path = os.path.join(os.path.dirname(__file__),
                         'test_template.task.ini')
+    root = RootTask()
     config = TemplateTaskConfig(manager=plugin,
-                                template_path=path)
+                                template_path=path,
+                                root=root)
     assert config.template_doc
     task = config.build_task()
     assert len(task.children) == 1

--- a/tests/tasks/configs/test_loop_config.py
+++ b/tests/tasks/configs/test_loop_config.py
@@ -12,6 +12,7 @@
 import enaml
 
 from exopy.testing.util import show_and_close_widget, show_widget
+from exopy.tasks.tasks.base_tasks import RootTask
 from exopy.tasks.configs.loop_config import (LoopTaskConfig)
 with enaml.imports():
     from exopy.tasks.configs.loop_config_view import LoopConfigView
@@ -23,8 +24,10 @@ def test_loop_config(exopy_qtbot, task_workbench):
     """
     plugin = task_workbench.get_plugin('exopy.tasks')
 
+    root = RootTask()
     config = LoopTaskConfig(manager=plugin,
-                            task_class=plugin.get_task('exopy.LoopTask'))
+                            task_class=plugin.get_task('exopy.LoopTask'),
+                            root=root)
 
     assert config.task_name
     assert config.ready
@@ -34,8 +37,20 @@ def test_loop_config(exopy_qtbot, task_workbench):
     assert not config.ready
 
     config.task_name = 'Test'
+    assert config.ready
     task = config.build_task()
     assert task.name == 'Test'
+
+    root.add_child_task(0, task)
+    config2 = LoopTaskConfig(manager=plugin,
+                             task_class=plugin.get_task('exopy.LoopTask'),
+                             root=root)
+
+    config2.task_name = 'Test'
+    assert not config2.ready
+
+    config2.task_name = 'ADifferentName'
+    assert config2.ready
 
     plugin.auto_task_names = []
     config = LoopTaskConfig(manager=plugin,
@@ -56,7 +71,8 @@ def test_loop_config_with_subtask(task_workbench, exopy_qtbot, dialog_sleep,
 
     config = LoopTaskConfig(manager=plugin,
                             task_class=plugin.get_task('exopy.LoopTask'),
-                            task_name='Test')
+                            task_name='Test',
+                            root=RootTask())
 
     show_widget(exopy_qtbot, LoopConfigView(config=config))
     assert config.ready

--- a/tests/tasks/configs/test_loop_config.py
+++ b/tests/tasks/configs/test_loop_config.py
@@ -27,7 +27,7 @@ def test_loop_config(exopy_qtbot, task_workbench):
     root = RootTask()
     config = LoopTaskConfig(manager=plugin,
                             task_class=plugin.get_task('exopy.LoopTask'),
-                            root=root)
+                            future_parent=root)
 
     assert config.task_name
     assert config.ready
@@ -44,7 +44,7 @@ def test_loop_config(exopy_qtbot, task_workbench):
     root.add_child_task(0, task)
     config2 = LoopTaskConfig(manager=plugin,
                              task_class=plugin.get_task('exopy.LoopTask'),
-                             root=root)
+                             future_parent=root)
 
     config2.task_name = 'Test'
     assert not config2.ready
@@ -71,8 +71,8 @@ def test_loop_config_with_subtask(task_workbench, exopy_qtbot, dialog_sleep,
 
     config = LoopTaskConfig(manager=plugin,
                             task_class=plugin.get_task('exopy.LoopTask'),
-                            task_name='Test',
-                            root=RootTask())
+                            future_parent=RootTask(),
+                            task_name='Test')
 
     show_widget(exopy_qtbot, LoopConfigView(config=config))
     assert config.ready

--- a/tests/tasks/utils/test_building.py
+++ b/tests/tasks/utils/test_building.py
@@ -38,7 +38,8 @@ def test_create_task1(exopy_qtbot, task_workbench, task_config):
                                dict(mode='from config', config=task_config,
                                     build_dep={}))
     with handle_dialog(exopy_qtbot, 'accept', answer_dialog):
-        res = core.invoke_command('exopy.tasks.create_task', dict(root=root))
+        res = core.invoke_command('exopy.tasks.create_task',
+                                  dict(future_parent=root))
         assert res
 
 
@@ -64,7 +65,8 @@ def test_create_task2(exopy_qtbot, task_workbench, dialog_sleep, task_config):
 
     root = RootTask()
     with handle_dialog(exopy_qtbot, 'reject', answer_dialog):
-        res = core.invoke_command('exopy.tasks.create_task', dict(root=root))
+        res = core.invoke_command('exopy.tasks.create_task',
+                                  dict(future_parent=root))
 
     assert res is None
 

--- a/tests/tasks/utils/test_building.py
+++ b/tests/tasks/utils/test_building.py
@@ -12,12 +12,13 @@
 import pytest
 from configobj import ConfigObj
 
+from exopy.tasks.tasks.base_tasks import RootTask
 from exopy.tasks.utils.building import build_task_from_config
 
 from exopy.testing.util import handle_dialog
 
 
-def test_create_task1(exopy_qtbot, task_workbench):
+def test_create_task1(exopy_qtbot, task_workbench, task_config):
     """Test creating a task.
 
     """
@@ -33,12 +34,15 @@ def test_create_task1(exopy_qtbot, task_workbench):
             assert dial.config.ready
         bot.wait_until(assert_dial_config_ready)
 
+    root = core.invoke_command('exopy.tasks.build_root',
+                               dict(mode='from config', config=task_config,
+                                    build_dep={}))
     with handle_dialog(exopy_qtbot, 'accept', answer_dialog):
-        res = core.invoke_command('exopy.tasks.create_task')
+        res = core.invoke_command('exopy.tasks.create_task', dict(root=root))
         assert res
 
 
-def test_create_task2(exopy_qtbot, task_workbench, dialog_sleep):
+def test_create_task2(exopy_qtbot, task_workbench, dialog_sleep, task_config):
     """Test handling user cancellation.
 
     """
@@ -58,8 +62,9 @@ def test_create_task2(exopy_qtbot, task_workbench, dialog_sleep):
         assert not dial.config
         exopy_qtbot.wait(dialog_sleep)
 
+    root = RootTask()
     with handle_dialog(exopy_qtbot, 'reject', answer_dialog):
-        res = core.invoke_command('exopy.tasks.create_task')
+        res = core.invoke_command('exopy.tasks.create_task', dict(root=root))
 
     assert res is None
 


### PR DESCRIPTION
- [x] Enforce unique names when creating a task
- [x] Enforce unique names when renaming a task
- [x] Update/add tests

Known issues:

- [x] Right click->Add after in the task tree bypasses uniqueness checks.
- [x] Copy-pasting doesn't work: the pasted task has the same name as the initial task. This seems hard to fix in a nice way because the behavior of `PasteAction` (in `qt_tree_menu.enaml`) is not overridable. EDIT: Found a hacky solution. EDIT2: Found a nicer solution.

Comment are welcome.