### PR TITLE
tasks: use proper encoding to read tasknames

### DIFF
--- a/exopy/tasks/plugin.py
+++ b/exopy/tasks/plugin.py
@@ -355,8 +355,9 @@ class TaskManagerPlugin(HasPreferencesPlugin):
                                 dict(kind='error', message=msg))
             return
 
-        with open(path) as f:
+        with open(path, encoding='utf-8') as f:
             aux = f.readlines()
+            print(aux)
 
         self.auto_task_names = [l.rstrip() for l in aux]
 

--- a/exopy/tasks/plugin.py
+++ b/exopy/tasks/plugin.py
@@ -357,7 +357,6 @@ class TaskManagerPlugin(HasPreferencesPlugin):
 
         with open(path, encoding='utf-8') as f:
             aux = f.readlines()
-            print(aux)
 
         self.auto_task_names = [l.rstrip() for l in aux]
 

--- a/exopy/tasks/tasknames.txt
+++ b/exopy/tasks/tasknames.txt
@@ -107,7 +107,7 @@ Vleck
 Kapitsa
 Penzias
 Wilson
-Glashow 
+Glashow
 Weinberg
 Salam
 Cronin
@@ -155,7 +155,7 @@ Tsui
 Hooft
 Veltman
 Kroemer
-Alferov 
+Alferov
 Kilby
 Cornell
 Wieman


### PR DESCRIPTION
Previously on windows we were using the locale encoding and Müller was not properly read. Thanks @lcontami to signal the bug.