### PR TITLE
setup: add PyQt5 to install requires only if PyQt is absent

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,9 @@ Exopy Changelog
 0.2.0 - unreleased
 ------------------
 
+- only include PyQt5 in install_requires if it is not present. This avoids
+  issues with pkg_resources and conda installed PyQt5 (not seen by setuptools
+  and pkg_resources)
 - always evaluate formula even if they contain only alpha characters PR # 132
 - fix unproperly unparented child task when removing a ComplexTask PR # 132
 - identify duplicate measurements in the waiting queue PR # 130 (fvalmorra)

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -17,12 +17,12 @@ build:
 
 requirements:
   host:
-    - python >=3.5
+    - python
     - pyqt >=5 # Add PyQt so that it does not appear in the package requires
                # which avoids issues when extension packages depending on exopy
                # check that all their dependencies are present.
   run:
-    - python >=3.5
+    - python
     - python.app       [osx]
     - enaml >=0.10.2
     - pyqt >=5

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -16,13 +16,16 @@ build:
   osx_is_app: True
 
 requirements:
-  build:
-    - python
+  host:
+    - python >=3.5
+    - pyqt >=5 # Add PyQt so that it does not appear in the package requires
+               # which avoids issues when extension packages depending on exopy
+               # check that all their dependencies are present.
   run:
-    - python
+    - python >=3.5
     - python.app       [osx]
     - enaml >=0.10.2
-    - pyqt
+    - pyqt >=5
     - atom >=0.4.1
     - kiwisolver >=1.0.0
     - watchdog

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,20 @@ import sys
 sys.path.insert(0, os.path.abspath('.'))
 from exopy.version import __version__
 
+install_requires = ['atom>=0.4.1', 'enaml>=0.10.2', 'kiwisolver>=1.0.0',
+                    'configobj', 'watchdog', 'qtawesome', 'numpy']
+
+# Avoid adding PyQt5 to install_requires if PyQt5 is already present. This
+# allows to avoid re-installing it if it is already present (typically in a
+# conda environment). This is not perfect but comes from
+# https://github.com/ContinuumIO/anaconda-issues/issues/1554 which prevents
+# setuptools to identify a conda install PyQt5 installation.
+# Based on https://github.com/glue-viz/glue/pull/1836
+try:
+    import PyQt5  # noqa
+except ImportError:
+    install_requires.append('PyQt5')
+
 
 def long_description():
     """Read the project description from the README file.
@@ -43,9 +57,6 @@ setup(
     package_data={'': ['*.enaml', '*.txt']},
     python_requires='>=3.5',
     setup_requires=['setuptools'],
-    install_requires=['atom>=0.4.1', 'enaml>=0.10.2',
-                      'kiwisolver>=1.0.0', 'configobj',
-                      'watchdog', 'qtawesome', 'numpy',
-                      'pyqt5'],
+    install_requires=install_requires,
     entry_points={'gui_scripts': 'exopy = exopy.__main__:main'},
 )


### PR DESCRIPTION
This is a kind of ugly trick to circumvent the fact that the conda pyqt package is not identified by setuptools nor pkg_resources which can lead to re-installing of failing the checks for requirements. The inconvenience should be minor since exopy cannot start without pyqt5.