### PR TITLE
Fix logger deprecation warnings

### DIFF
--- a/exopy/app/icons/plugin.py
+++ b/exopy/app/icons/plugin.py
@@ -112,7 +112,7 @@ class IconManagerPlugin(HasPreferencesPlugin):
                     msg = msg % (self.fallback_theme, icon_id)
 
             logger = logging.getLogger(__name__)
-            logger.warn(msg)
+            logger.warning(msg)
 
         return icon
 

--- a/exopy/app/log/plugin.py
+++ b/exopy/app/log/plugin.py
@@ -141,7 +141,7 @@ class LogPlugin(Plugin):
         """
         if not hasattr(filter, 'filter'):
             logger = logging.getLogger(__name__)
-            logger.warn('Filter does not implemet a filter method')
+            logger.warning('Filter does not implemet a filter method')
             return
 
         handlers = self._handlers
@@ -154,7 +154,7 @@ class LogPlugin(Plugin):
 
         else:
             logger = logging.getLogger(__name__)
-            logger.warn('Handler {} does not exist')
+            logger.warning('Handler {} does not exist')
 
     def remove_filter(self, id):
         """Remove the specified filter.
@@ -192,7 +192,7 @@ class LogPlugin(Plugin):
 
         else:
             logger = logging.getLogger(__name__)
-            logger.warn('Handler {} does not exist')
+            logger.warning('Handler {} does not exist')
 
     # ---- Private API --------------------------------------------------------
 

--- a/exopy/instruments/plugin.py
+++ b/exopy/instruments/plugin.py
@@ -272,7 +272,7 @@ class InstrumentManagerPlugin(HasPreferencesPlugin):
         """
         if settings_id is None:
             msg = 'No id was found for the settings whose infos are %s'
-            logger.warn(msg, infos)
+            logger.warning(msg, infos)
             return None
         s_decl = self._settings.contributions[settings_id]
         sett = s_decl.new(self.workbench, infos, read_only)
@@ -483,9 +483,9 @@ class InstrumentManagerPlugin(HasPreferencesPlugin):
                     if res:
                         profiles[name] = i
                     else:
-                        logger.warn(msg)
+                        logger.warning(msg)
             else:
-                logger.warn('{} is not a valid directory'.format(path))
+                logger.warning('{} is not a valid directory'.format(path))
 
         self._profiles = profiles
 

--- a/exopy/measurement/monitors/text_monitor/plugin.py
+++ b/exopy/measurement/monitors/text_monitor/plugin.py
@@ -115,7 +115,7 @@ class TextMonitorPlugin(HasPreferencesPlugin):
                 config['id'] = name_or_config
             else:
                 msg = 'Requested rule not found : {}'.format(name_or_config)
-                logger.warn(msg)
+                logger.warning(msg)
                 return
 
         else:
@@ -130,7 +130,7 @@ class TextMonitorPlugin(HasPreferencesPlugin):
 
         else:
             msg = 'Requested rule class not found : {}'.format(class_id)
-            logger.warn(msg)
+            logger.warning(msg)
 
     def get_rule_type(self, rule_type_id):
         """Access the class corresponding to a given id.

--- a/exopy/measurement/workspace/workspace.py
+++ b/exopy/measurement/workspace/workspace.py
@@ -497,21 +497,21 @@ class MeasurementSpace(Workspace):
                 measurement.add_tool('pre-hook', pre_id)
             else:
                 msg = "Default pre-execution hook {} not found"
-                logger.warn(msg.format(pre_id))
+                logger.warning(msg.format(pre_id))
 
         for monitor_id in self.plugin.default_monitors:
             if monitor_id in self.plugin.monitors:
                 measurement.add_tool('monitor', monitor_id)
             else:
                 msg = "Default monitor {} not found."
-                logger.warn(msg.format(monitor_id))
+                logger.warning(msg.format(monitor_id))
 
         for post_id in self.plugin.default_post_hooks:
             if post_id in self.plugin.post_hooks:
                 measurement.add_tool('post-hook', post_id)
             else:
                 msg = "Default post-execution hook {} not found"
-                logger.warn(msg.format(post_id))
+                logger.warning(msg.format(post_id))
 
     def _insert_new_edition_panels(self, measurements, update=True,
                                    panels=None):

--- a/exopy/tasks/plugin.py
+++ b/exopy/tasks/plugin.py
@@ -403,7 +403,7 @@ class TaskManagerPlugin(HasPreferencesPlugin):
                     templates[name] = template_path
             else:
                 logger = logging.getLogger(__name__)
-                logger.warn('{} is not a valid directory'.format(path))
+                logger.warning('{} is not a valid directory'.format(path))
 
         self.templates = templates
 

--- a/tests/app/log/test_tools.py
+++ b/tests/app/log/test_tools.py
@@ -58,7 +58,7 @@ def test_gui_handler(exopy_qtbot, logger, monkeypatch):
     exopy_qtbot.wait_until(assert_text)
     model.clean_text()
 
-    logger.warn('test')
+    logger.warning('test')
 
     def assert_text():
         assert model.text == 'WARNING: test\n'


### PR DESCRIPTION
`warn()` is deprecated and needs to be substituted with `warning()`.
This commit fixes this issue. Hope this helps to resolve part of #159. If you want anything to be changed I would be happy to update and resubmit this pull request.