### PR TITLE
Fix runtime dependencies collection pruning

### DIFF
--- a/docs/source/dev_guide/tasks.rst
+++ b/docs/source/dev_guide/tasks.rst
@@ -731,7 +731,7 @@ Edition mode vs running mode
 In some places in the code, one may find references to the notion of running
 mode for the database. This mode should be activated when the edition of the
 tasks hierarchy is over as it allows to speed up a number of operations. In
-running mode, the databased is flattened to allow fast repeated access to the
+running mode, the database is flattened to allow fast repeated access to the
 same entry by first querying its index and then using that index for getting
 the value. Because of this, no entry can be added or removed from the database.
 Another optimization is performed by caching a pre-evaluated version of all

--- a/exopy/app/dependencies/dependencies.py
+++ b/exopy/app/dependencies/dependencies.py
@@ -210,10 +210,10 @@ class RuntimeDependencyCollector(Declarative):
             know the ressource owner.
 
         dependencies : dict
-            Dictionary whose values are initialised to None listing the
+            Dictionary whose values are initialized to None listing the
             dependencies to collect.
 
-        unavaible : set
+        unavailable : set
             Set of resources that could not be provided because they are
             currently unavailable.
 

--- a/exopy/app/dependencies/plugin.py
+++ b/exopy/app/dependencies/plugin.py
@@ -44,7 +44,7 @@ class BuildContainer(Atom):
     #: Dictionary storing the collected dependencies, grouped by id.
     dependencies = Typed(dict)
 
-    #: Dictionary storing the errors which occured during collection.
+    #: Dictionary storing the errors which occurred during collection.
     errors = Typed(dict)
 
     def clean(self):
@@ -311,6 +311,8 @@ class DependenciesPlugin(Plugin):
             the requested dependencies.
 
         """
+        # Create a dictionary for each dep_id whose values are None and will
+        # be replaced by the collected dependencies after collections.
         dependencies = {k: dict.fromkeys(v)
                         for k, v in dependencies.items()}
 
@@ -352,6 +354,11 @@ class DependenciesPlugin(Plugin):
                 except Exception:
                     container.errors[dep_id] =\
                         'An unhandled exception occured :\n%s' % format_exc()
+                # Remove uncollected dependencies from the list of
+                # dependencies by filtering out None values.
+                dependencies[dep_id] =\
+                    {k: v for k, v in dependencies[dep_id].items()
+                     if v is not None}
 
         else:
             raise ValueError("kind argument must be 'build' or 'runtime' not :"

--- a/exopy/instruments/plugin.py
+++ b/exopy/instruments/plugin.py
@@ -365,7 +365,7 @@ class InstrumentManagerPlugin(HasPreferencesPlugin):
             return {}, unavailable
 
         available = ([p for p in profiles if p not in unavailable]
-                     if unavailable else profiles)
+                      if unavailable else profiles)
 
         with self.suppress_notifications():
             u = self.used_profiles

--- a/exopy/measurement/engines/utils.py
+++ b/exopy/measurement/engines/utils.py
@@ -86,7 +86,7 @@ class ThreadMeasureMonitor(Thread):
             try:
                 news = self.queue.get()
                 if news not in [(None, None), ('', '')]:
-                    # Here news is a Signal not Event hence the syntax.
+                    # Here progress is a Signal not an Event hence the syntax.
                     self.engine.progress(news)
                 elif news == ('', ''):
                     logger = logging.getLogger(__name__)

--- a/exopy/measurement/measurement.py
+++ b/exopy/measurement/measurement.py
@@ -173,7 +173,13 @@ class MeasurementDependencies(Atom):
 
     def get_runtime_dependencies(self, id):
         """Access the runtime dependencies associated with a hook or the main
-        task
+        task.
+
+        Those will correspond to the runtime dependencies that were collected.
+        Dependencies that have not been collected, because they are not
+        available for example, will not appear in here. However it is
+        guaranteed that sections corresponding to each kind of runtime
+        dependencies will be present even if they are empty.
 
         Parameters
         ----------
@@ -205,7 +211,10 @@ class MeasurementDependencies(Atom):
         deps = self._runtime_dependencies
         queried = {}
         for runtime_id, r_deps in valids.items():
-            queried[runtime_id] = {k: deps[runtime_id][k] for k in r_deps}
+            if runtime_id in deps:
+                queried[runtime_id] = {k: deps[runtime_id][k] for k in r_deps}
+            else:
+                queried[runtime_id] = {}
 
         return queried
 

--- a/exopy/tasks/tasks/instr_task.py
+++ b/exopy/tasks/tasks/instr_task.py
@@ -56,10 +56,12 @@ class InstrumentTask(SimpleTask):
         if self.selected_instrument and len(self.selected_instrument) == 4:
             p_id, d_id, c_id, s_id = self.selected_instrument
             self.write_in_database('instrument', p_id)
-            if PROFILE_DEPENDENCY_ID in run_time:
-                # Here use .get() to avoid errors if we were not granted the
-                # use of the profile. In that case config won't be used.
-                profile = run_time[PROFILE_DEPENDENCY_ID].get(p_id)
+            # Here use .get() to avoid errors if we were not granted the
+            # use of the profile. In that case config won't be used.
+            # Note that the Measurement guarantees that all requested runtime
+            # dependencies section will be present even if they are empty,
+            # which makes it safe to access PROFILE_DEPENDENCY_ID
+            profile = run_time[PROFILE_DEPENDENCY_ID].get(p_id)
         else:
             msg = ('No instrument was selected or not all informations were '
                    'provided. The instrument selected should be specified as '

--- a/tests/app/dependencies/dependencies_utils.enaml
+++ b/tests/app/dependencies/dependencies_utils.enaml
@@ -91,13 +91,13 @@ enamldef RuntimeDep(PluginManifest):
             collect => (workbench, owner, dependencies, unavailable, errors):
                 if exc:
                     raise RuntimeError()
+                dependencies['run_bis'] = 1
                 if err:
                     errors['run'] = 'Failed to get run'
-                    return
-                if una:
+                elif una:
                     unavailable.add('run')
-                    return
-                dependencies['run'] = 1
+                else:
+                    dependencies['run'] = 1
 
             release => (workbench, owner, dependencies):
                 del dependencies['run']

--- a/tests/app/dependencies/test_plugin.py
+++ b/tests/app/dependencies/test_plugin.py
@@ -6,7 +6,7 @@
 #
 # The full license is in the file LICENCE, distributed with this software.
 # -----------------------------------------------------------------------------
-"""Test DependenciesManagerPLugin behavior.
+"""Test DependenciesManagerPlugin behavior.
 
 """
 import pytest

--- a/tests/app/dependencies/test_plugin.py
+++ b/tests/app/dependencies/test_plugin.py
@@ -382,6 +382,8 @@ def test_collecting_unavailable_runtime(dep_workbench, runtime_deps):
                                         'owner': plugin.manifest.id},
                               )
     assert not dep.errors
+    assert 'run_bis' in dep.dependencies['test_run_collect']
+    assert 'run' not in dep.dependencies['test_run_collect']
     assert dep.unavailable['test_run_collect'] == {'run'}
 
 

--- a/tests/measurement/test_measurement.py
+++ b/tests/measurement/test_measurement.py
@@ -332,7 +332,7 @@ def test_collecting_runtime(measurement, monkeypatch):
     # Access for known id
     assert measurement.dependencies.get_runtime_dependencies('dummy')
 
-    # Release and test impossibilty to access for uncollected deps.
+    # Release and test impossibility to access for uncollected deps.
     measurement.dependencies.release_runtimes()
     with pytest.raises(RuntimeError):
         measurement.dependencies.get_runtime_dependencies('dummy')

--- a/tests/measurement/test_measurement.py
+++ b/tests/measurement/test_measurement.py
@@ -306,6 +306,9 @@ def test_collecting_runtime(measurement, monkeypatch):
     res, msg, errors = measurement.dependencies.collect_runtimes()
     assert not res
     assert 'unavailable' in msg
+    deps = measurement.dependencies
+    assert 'dummy1' in deps.get_runtime_dependencies('main')
+    assert deps.get_runtime_dependencies('main')['dummy1'] == {}
     measurement.dependencies.release_runtimes()
 
     # Runtimes unavailable for hooks


### PR DESCRIPTION
The dependencies dict is initialized as a dict with None values. Values are updated by the collection process but uncollected values were not removed. As a consequence, even though they were not collected they were released ! This is the origin of the bug caught by the ADQ14.

The first commit address the issue, the second simply some typos caught by vs code spell checker.


Closes https://github.com/Exopy/exopy_hqc_legacy/issues/50