### PR TITLE
Text monitor: Add a scroll bar

### DIFF
--- a/exopy/measurement/monitors/text_monitor/monitor_views.enaml
+++ b/exopy/measurement/monitors/text_monitor/monitor_views.enaml
@@ -14,7 +14,7 @@ from operator import attrgetter
 from enaml.core.api import Looper, Conditional
 from enaml.layout.api import hbox, spacer, vbox
 from enaml.widgets.api import (PushButton, Container, CheckBox, Label, Field,
-                               CheckBox, Form)
+                               CheckBox, Form, ScrollArea)
 from enaml.stdlib.message_box import question
 
 from ....utils.widgets.qt_list_str_widget import QtListStrWidget
@@ -162,15 +162,22 @@ enamldef TextMonitorItem(BaseMonitorItem):
     """DockItem the monitor infos about the measurement.
 
     """
+    #: Default maximum height of the window
+    attr max_height = 700
+
     title = 'Text monitor'
 
-    Form: form:
-        Looper:
-            iterable << (sorted(monitor.displayed_entries,
-                                key=attrgetter('path')) if monitor else [])
-            Label:
-                hug_width = 'strong'
-                text << loop_item.name
-            Field:
-                read_only = True
-                text << loop_item.value
+    Container: form:
+        padding = 0
+        ScrollArea:
+            constraints = [height <= max_height]
+            Form:
+                Looper:
+                    iterable << (sorted(monitor.displayed_entries,
+                                        key=attrgetter('path')) if monitor else [])
+                    Label:
+                        hug_width = 'strong'
+                        text << loop_item.name
+                    Field:
+                        read_only = True
+                        text << loop_item.value

--- a/tests/measurement/monitors/text_monitor/test_monitor.py
+++ b/tests/measurement/monitors/text_monitor/test_monitor.py
@@ -635,7 +635,7 @@ def test_text_monitor_item(exopy_qtbot, text_monitor_workbench, monitor,
                                                      name='test'))
     w.show()
     wait_for_window_displayed(exopy_qtbot, w)
-    f = w.widget.dock_widget()
+    f = w.widget.dock_widget().widgets()[0].scroll_widget()
     assert (sorted([l.text for l in f.widgets()[::2]]) ==
             sorted([e.name for e in monitor.displayed_entries]))
     exopy_qtbot.wait(dialog_sleep)


### PR DESCRIPTION
This code was written by Antoine Essig and adds a scrollbar to the text monitor window which is very useful when dealing with large amounts of monitors. 