### PR TITLE
Loop_task: add loop_values to the database

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,8 @@ Exopy Changelog
 - always evaluate formula even if they contain only alpha characters PR # 132
 - fix unproperly unparented child task when removing a ComplexTask PR # 132
 - identify duplicate measurements in the waiting queue PR # 130 (fvalmorra)
+- add a "loop_values" database entry to LoopTask which contains the list of
+  all values the loop will iterate through PR #168 (rassouly)
 
 
 0.1.0 - 15-02-2018

--- a/exopy/tasks/tasks/logic/loop_iterable_interface.py
+++ b/exopy/tasks/tasks/logic/loop_iterable_interface.py
@@ -37,7 +37,7 @@ class IterableLoopInterface(TaskInterface):
         task = self.task
         iterable = task.format_and_eval_string(self.iterable)
         task.write_in_database('point_number', len(iterable))
-        task.write_in_database('loop_values', numpy.array(iterable))
+        task.write_in_database('loop_values', np.array(iterable))
         if 'value' in task.database_entries:
             task.write_in_database('value', next(iter(iterable)))
 

--- a/exopy/tasks/tasks/logic/loop_iterable_interface.py
+++ b/exopy/tasks/tasks/logic/loop_iterable_interface.py
@@ -9,6 +9,8 @@
 """Interface allowing to use an iterable in a LoopTask.
 
 """
+import numpy
+
 from atom.api import Unicode
 from collections import Iterable
 
@@ -35,6 +37,7 @@ class IterableLoopInterface(TaskInterface):
         task = self.task
         iterable = task.format_and_eval_string(self.iterable)
         task.write_in_database('point_number', len(iterable))
+        task.write_in_database('loop_values', numpy.array(iterable))
         if 'value' in task.database_entries:
             task.write_in_database('value', next(iter(iterable)))
 

--- a/exopy/tasks/tasks/logic/loop_iterable_interface.py
+++ b/exopy/tasks/tasks/logic/loop_iterable_interface.py
@@ -9,7 +9,7 @@
 """Interface allowing to use an iterable in a LoopTask.
 
 """
-import numpy
+import numpy as np
 
 from atom.api import Unicode
 from collections import Iterable

--- a/exopy/tasks/tasks/logic/loop_linspace_interface.py
+++ b/exopy/tasks/tasks/logic/loop_linspace_interface.py
@@ -98,4 +98,5 @@ class LinspaceLoopInterface(TaskInterface):
         iterable = np.fromiter((round(value, digit)
                                 for value in raw_values),
                                np.float, len(raw_values))
+        task.write_in_database('loop_values', np.array(iterable))
         task.perform_loop(iterable)

--- a/exopy/tasks/tasks/logic/loop_task.py
+++ b/exopy/tasks/tasks/logic/loop_task.py
@@ -9,6 +9,8 @@
 """Task allowing to perform a loop. The iterable is given by an interface.
 
 """
+import numpy
+
 from atom.api import (Typed, Bool, set_default)
 
 from timeit import default_timer
@@ -30,8 +32,8 @@ class LoopTask(InterfaceableTaskMixin, ComplexTask):
     #: is simply a convenience and can be set to None.
     task = Typed(SimpleTask).tag(child=50)
 
-    database_entries = set_default({'point_number': 11, 'index': 1,
-                                    'value': 0})
+    database_entries = set_default({'point_number': 11, 'index': 1, 'value': 0,
+                                    'loop_values':numpy.array([0])})
 
     def check(self, *args, **kwargs):
         """Overriden so that interface check are run before children ones.
@@ -84,6 +86,7 @@ class LoopTask(InterfaceableTaskMixin, ComplexTask):
 
         """
         self.write_in_database('point_number', len(iterable))
+        self.write_in_database('loop_values', numpy.array(iterable))
 
         root = self.root
         for i, value in enumerate(iterable):
@@ -106,6 +109,7 @@ class LoopTask(InterfaceableTaskMixin, ComplexTask):
 
         """
         self.write_in_database('point_number', len(iterable))
+        self.write_in_database('loop_values', numpy.array(iterable))
 
         root = self.root
         for i, value in enumerate(iterable):
@@ -128,6 +132,7 @@ class LoopTask(InterfaceableTaskMixin, ComplexTask):
 
         """
         self.write_in_database('point_number', len(iterable))
+        self.write_in_database('loop_values', numpy.array(iterable))
 
         root = self.root
         for i, value in enumerate(iterable):
@@ -154,6 +159,7 @@ class LoopTask(InterfaceableTaskMixin, ComplexTask):
 
         """
         self.write_in_database('point_number', len(iterable))
+        self.write_in_database('loop_values', numpy.array(iterable))
 
         root = self.root
         for i, value in enumerate(iterable):

--- a/exopy/tasks/tasks/logic/loop_task.py
+++ b/exopy/tasks/tasks/logic/loop_task.py
@@ -33,7 +33,7 @@ class LoopTask(InterfaceableTaskMixin, ComplexTask):
     task = Typed(SimpleTask).tag(child=50)
 
     database_entries = set_default({'point_number': 11, 'index': 1, 'value': 0,
-                                    'loop_values':numpy.array([0])})
+                                    'loop_values':np.linspace(0, 1, 11)})
 
     def check(self, *args, **kwargs):
         """Overriden so that interface check are run before children ones.

--- a/exopy/tasks/tasks/logic/loop_task.py
+++ b/exopy/tasks/tasks/logic/loop_task.py
@@ -9,7 +9,7 @@
 """Task allowing to perform a loop. The iterable is given by an interface.
 
 """
-import numpy
+import numpy as np
 
 from atom.api import (Typed, Bool, set_default)
 

--- a/exopy/tasks/tasks/logic/loop_task.py
+++ b/exopy/tasks/tasks/logic/loop_task.py
@@ -86,7 +86,7 @@ class LoopTask(InterfaceableTaskMixin, ComplexTask):
 
         """
         self.write_in_database('point_number', len(iterable))
-        self.write_in_database('loop_values', numpy.array(iterable))
+        self.write_in_database('loop_values', np.array(iterable))
 
         root = self.root
         for i, value in enumerate(iterable):
@@ -109,7 +109,7 @@ class LoopTask(InterfaceableTaskMixin, ComplexTask):
 
         """
         self.write_in_database('point_number', len(iterable))
-        self.write_in_database('loop_values', numpy.array(iterable))
+        self.write_in_database('loop_values', np.array(iterable))
 
         root = self.root
         for i, value in enumerate(iterable):
@@ -132,7 +132,7 @@ class LoopTask(InterfaceableTaskMixin, ComplexTask):
 
         """
         self.write_in_database('point_number', len(iterable))
-        self.write_in_database('loop_values', numpy.array(iterable))
+        self.write_in_database('loop_values', np.array(iterable))
 
         root = self.root
         for i, value in enumerate(iterable):
@@ -159,7 +159,7 @@ class LoopTask(InterfaceableTaskMixin, ComplexTask):
 
         """
         self.write_in_database('point_number', len(iterable))
-        self.write_in_database('loop_values', numpy.array(iterable))
+        self.write_in_database('loop_values', np.array(iterable))
 
         root = self.root
         for i, value in enumerate(iterable):


### PR DESCRIPTION
This patch was originally written by Zaki Leghtas and is present in
the catlab branch. It adds a loop_values element to the database
containing a list of all the values that the loop will iterate
through.