### PR TITLE
VISA Raw connections fix

### DIFF
--- a/exopy/instruments/connections/visa_connections.enaml
+++ b/exopy/instruments/connections/visa_connections.enaml
@@ -30,6 +30,11 @@ enamldef VisaRaw(BaseConnection): main:
     #: Full visa resource name. Can be an alias or an address added manually.
     attr resource_name: str = ''
 
+    #: For compatibility with the other Visa connections
+    attr infos: list = ['resource_name']
+
+    title = 'VISA raw'
+
     constraints = [hbox(rn_lab, rn_val)]
 
     Label: rn_lab:

--- a/tests/instruments/connections/test_visa_connections.py
+++ b/tests/instruments/connections/test_visa_connections.py
@@ -153,7 +153,14 @@ def test_creating_a_visa_connection(prof_plugin, exopy_qtbot, caplog):
 
 
 @pytest.mark.parametrize('id, defaults, should_log',
-                         [('VisaRS232',
+                         [('VisaRaw',
+                           {'resource_name': 'COM1'},
+                           False),
+                          ('VisaRaw',
+                           {'resource_name': 'COM1',
+                            'bad': 1},
+                           True),
+                          ('VisaRS232',
                            {'interface_type': 'ASRL',
                             'resource_class': 'INSTR',
                             'board': 1},


### PR DESCRIPTION
This fixes some bug caused by 2f6d9bdde0afd13edd1df39fff945434b1de8e17 (I think) that caused the profile selection window to crash whenever an instrument with a VISARaw connection was selected.
