### PR TITLE
InstrTask: Extend test_driver to work outside of a measurement

### DIFF
--- a/exopy/tasks/tasks/instr_view.enaml
+++ b/exopy/tasks/tasks/instr_view.enaml
@@ -15,9 +15,6 @@ from enaml.layout.api import hbox
 from .base_views import BaseTaskView
 
 
-# TODO add a context manager allowing to get a temporary access to a driver
-
-
 enamldef InstrTaskView(BaseTaskView):
     """Base view for task needing to connect to an instrument.
 


### PR DESCRIPTION
I didn't like duplicating the existing `test_driver` method to a new function in the instr_view.enaml file so I instead added a `core` parameter to the existing `test_driver` method.
I find it unfortunate that tasks have no direct access tot the `workbench` or `core`: this forces the tasks that use this method to transfer the core plugin from their views to their task. Is there a reason why this `core` is not an attribute of RootTask or was there simply no use for it before?