### PR TITLE
Add a way to temporarily acquire the runtime necessary to run a single task

### DIFF
--- a/exopy/measurement/manifest.enaml
+++ b/exopy/measurement/manifest.enaml
@@ -16,6 +16,7 @@ from pprint import pformat
 import enaml
 from enaml.stdlib.message_box import warning
 from enaml.workbench.api import PluginManifest, ExtensionPoint, Extension
+from enaml.workbench.core.api import Command
 from enaml.workbench.ui.api import ActionItem
 
 from ..app.api import AppClosing
@@ -23,6 +24,7 @@ from ..app.preferences.api import Preferences
 from ..app.errors.api import ErrorHandler
 from ..app.errors.widgets import HierarchicalErrorsDisplay
 from ..instruments.api import InstrUser
+from ..utils.plugin_tools import make_handler
 
 from .engines.process_engine import ProcessEngine
 from .editors.api import Editor
@@ -274,3 +276,11 @@ enamldef MeasureManifest(PluginManifest): manifest:
             group = 'spaces'
             command = 'enaml.workbench.ui.select_workspace'
             parameters = {'workspace': 'exopy.measurement.workspace'}
+
+    Extension:
+        id = 'commands'
+        point = 'enaml.workbench.core.commands'
+        Command:
+            id = 'exopy.measurement.get_task_runtime'
+            description = GET_TASK_RUNTIME_DESCRIPTION
+            handler = make_handler('exopy.measurement', 'get_task_runtime')

--- a/exopy/measurement/plugin.py
+++ b/exopy/measurement/plugin.py
@@ -43,13 +43,17 @@ def _workspace():
 
 
 class TaskRuntimeContext():
+    """A context manager used to give temporary access to a task runtime
+    (e.g. driver) to a task.
+
+    """
     def __init__(self, dependencies, task):
         self.dependencies = dependencies
         self.task = task
 
     def __enter__(self):
-        r, msg, errors = self.dependencies.collect_task_runtimes(self.task)
-        if r:
+        res, msg, errors = self.dependencies.collect_task_runtimes(self.task)
+        if res:
             self.task.root.run_time = self.dependencies.get_runtime_dependencies('main')
         else:
             logger.error(msg)
@@ -311,6 +315,23 @@ class MeasurementPlugin(HasPreferencesPlugin):
         return measurement
 
     def get_task_runtime(self, measurement, task):
+        """Give temporary access to a task runtime
+
+        Parameters
+        ----------
+        measurement: Measurement
+            Measurement used to analyse and collect runtime
+        task: Task:
+            Task whose dependencies are going to be analysed
+            and collected. Must be part of the measurement.
+
+        Returns
+        -------
+        runtime: TaskRuntimeContext
+            A context manager that acquires and releases the task
+            dependencies.
+
+        """
         return TaskRuntimeContext(measurement.dependencies, task)
 
     # =========================================================================

--- a/exopy/measurement/plugin.py
+++ b/exopy/measurement/plugin.py
@@ -58,6 +58,7 @@ class TaskRuntimeContext():
         else:
             logger.error(msg)
             logger.error(errors)
+        return res, msg, errors
 
     def __exit__(self, type, value, traceback):
         self.task.root.run_time = {}

--- a/exopy/tasks/tasks/instr_task.py
+++ b/exopy/tasks/tasks/instr_task.py
@@ -142,7 +142,7 @@ class InstrumentTask(SimpleTask):
             d_cls, starter = run_time[DRIVER_DEPENDENCY_ID][d_id]
             driver = starter.start(d_cls,
                                    profile['connections'][c_id],
-                                   profile['settings'][s_id])
+                                   profile['settings'].get(s_id, {}))
         except Exception:
             driver = None
 


### PR DESCRIPTION
This achieves the same result as #171 but in a cleaner way. It includes a small refactor of the measurement class.

I still need to add a helper to the task view to make it easier to get the measurement object ~~and some documentation~~.