### PR TITLE
Fix TextMonitor monitoring non-displayed entries

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -13,6 +13,8 @@ Exopy Changelog
 - identify duplicate measurements in the waiting queue PR # 130 (fvalmorra)
 - add a "loop_values" database entry to LoopTask which contains the list of
   all values the loop will iterate through PR #168 (rassouly)
+- measurement/monitor: fix a bug in TextMonitor where some undisplayed entries
+  where needlessely monitored (rassouly)
 
 
 0.1.0 - 15-02-2018

--- a/exopy/measurement/monitors/text_monitor/monitor.py
+++ b/exopy/measurement/monitors/text_monitor/monitor.py
@@ -337,9 +337,10 @@ class TextMonitor(BaseMonitor):
             self.displayed_entries = disp
             self.undisplayed_entries = undisp
             self.hidden_entries = hidden
-            for e in undisp + hidden:
-                if e.path in self.monitored_entries:
-                    self.monitored_entries.remove(e.path)
+            self.monitored_entries = []
+            self.updaters = {}
+            for e in set(disp):
+                self._displayed_entry_added(e)
 
     def add_entries(self, section, entries):
         """Add entries to the specified section.

--- a/exopy/measurement/monitors/text_monitor/monitor.py
+++ b/exopy/measurement/monitors/text_monitor/monitor.py
@@ -337,6 +337,9 @@ class TextMonitor(BaseMonitor):
             self.displayed_entries = disp
             self.undisplayed_entries = undisp
             self.hidden_entries = hidden
+            for e in undisp + hidden:
+                if e.path in self.monitored_entries:
+                    self.monitored_entries.remove(e.path)
 
     def add_entries(self, section, entries):
         """Add entries to the specified section.

--- a/tests/measurement/monitors/text_monitor/test_monitor.py
+++ b/tests/measurement/monitors/text_monitor/test_monitor.py
@@ -424,6 +424,9 @@ def test_get_set_state(monitor, monkeypatch, measurement, database):
     database.set_value('root', 'test2_index', 1)
     database.set_value('root', 'test2_loop', 10)
 
+    monitor.move_entries("displayed", "undisplayed",
+                         [e for e in monitor.displayed_entries if "test2" in e.path])
+
     state = monitor.get_state()
 
     assert 'rule_0' in state
@@ -473,10 +476,12 @@ def test_get_set_state(monitor, monkeypatch, measurement, database):
     monitor.link_to_measurement(measurement)
 
     assert not monitor._state
-    print(sorted([e.path for e in monitor.displayed_entries]))
     assert (sorted([e.path for e in monitor.displayed_entries]) ==
-            sorted(['custom', 'root/test_progress', 'root/test2_progress',
-                    'root/r']))
+            sorted(['custom', 'root/test_progress', 'root/r']))
+    # custom is not in because it's not in the database but test2_loop is in because
+    # custom depends on it
+    assert set(monitor.monitored_entries) == set(["root/r", "root/test_index",
+                                                  "root/test_loop", "root/test2_loop"])
 
 
 def test_known_monitored_entries(monitor):


### PR DESCRIPTION
I think I found the issue that I clumsily tried to fix in my previous PR. A function in `TextMonitor` was not properly restoring the `monitored_entries` list causing it to actually contain most of the entries even if none were displayed. With this fix, only the displayed entries are actually monitored. In some measurements, I can get a 10% performance increase by just removing some monitors from the list of displayed monitors that I was not getting before this patch. It also fixes the large memory usage caused by monitoring large recarrays by giving the user the ability to not monitor such arrays. 
Note that the code in `TextMonitor` is extremely brittle because it tries to maintain by hand the fact that `monitored_entries` contains exclusively the paths of the displayed entries by adding, removing and updating entries in sync (or in this case, failing to do so).