### PR TITLE
Headless mode

### DIFF
--- a/exopy/__main__.py
+++ b/exopy/__main__.py
@@ -33,6 +33,7 @@ with enaml.imports():
     from exopy.app.icons.manifest import IconManagerManifest
     from exopy.app.packages.manifest import PackagesManifest
     from exopy.app.log.manifest import LogManifest
+    from exopy.app.headless.manifest import HeadlessManifest    
     from exopy.measurement.manifest import MeasureManifest
     from exopy.measurement.monitors.text_monitor.manifest\
         import TextMonitorManifest
@@ -202,6 +203,9 @@ def main(cmd_line_args=None):
     parser.add_argument("-r", "--reset-app-folder",
                         help='Reset the application startup folder.',
                         action='store_true')
+    parser.add_argument("-x", "--execute",
+                        help="Execute given measurement file")
+    
 
     modifiers = []
     for i, ep in enumerate(iter_entry_points('exopy_cmdline_args')):
@@ -256,6 +260,7 @@ def main(cmd_line_args=None):
     workbench.register(TasksManagerManifest())
     workbench.register(MeasureManifest())
     workbench.register(TextMonitorManifest())
+    workbench.register(HeadlessManifest())
 
     ui = workbench.get_plugin(u'enaml.workbench.ui')  # Create the application
 
@@ -289,6 +294,7 @@ def main(cmd_line_args=None):
 
     # Unregister all contributed packages
     workbench.unregister('exopy.app.packages')
+    workbench.unregister('exopy.app.headless')
     workbench.unregister('exopy.measurement.monitors.text_monitor')
     workbench.unregister('exopy.measurement')
     workbench.unregister('exopy.tasks')

--- a/exopy/__main__.py
+++ b/exopy/__main__.py
@@ -33,7 +33,7 @@ with enaml.imports():
     from exopy.app.icons.manifest import IconManagerManifest
     from exopy.app.packages.manifest import PackagesManifest
     from exopy.app.log.manifest import LogManifest
-    from exopy.app.headless.manifest import HeadlessManifest    
+    from exopy.app.headless.manifest import HeadlessManifest
     from exopy.measurement.manifest import MeasureManifest
     from exopy.measurement.monitors.text_monitor.manifest\
         import TextMonitorManifest
@@ -205,7 +205,6 @@ def main(cmd_line_args=None):
                         action='store_true')
     parser.add_argument("-x", "--execute",
                         help="Execute given measurement file")
-    
 
     modifiers = []
     for i, ep in enumerate(iter_entry_points('exopy_cmdline_args')):
@@ -273,6 +272,10 @@ def main(cmd_line_args=None):
                    'application start ups :\n {}'.format(e))
         details = format_exc()
         display_startup_error_dialog(text, content, details)
+
+    # Quit hard and early if we are headless mode
+    if args.execute:
+        return
 
     core = workbench.get_plugin('enaml.workbench.core')
 

--- a/exopy/app/headless/autoclose.py
+++ b/exopy/app/headless/autoclose.py
@@ -1,0 +1,7 @@
+from ...measurement.hooks.base_hooks import BasePostExecutionHook
+
+class AutoClose(BasePostExecutionHook):
+    def run(self, workbench, engine):
+        print('  Closing Exopy...')
+        ui = workbench.get_plugin(u'enaml.workbench.ui')
+        ui.stop_application()

--- a/exopy/app/headless/manifest.enaml
+++ b/exopy/app/headless/manifest.enaml
@@ -80,7 +80,7 @@ enamldef HeadlessManifest(PluginManifest):
         point = 'exopy.app.startup'
         AppStartup:
             id = 'exopy.app.headless'
-            priority = 1
+            priority = 20
             run => (workbench, cmd_args):
                 start_headless_measurement(workbench, cmd_args)
     Extension:

--- a/exopy/app/headless/manifest.enaml
+++ b/exopy/app/headless/manifest.enaml
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright 2021 by Exopy Authors, see AUTHORS for more details.
+#
+# Distributed under the terms of the BSD license.
+#
+# The full license is in the file LICENCE, distributed with this software.
+# -----------------------------------------------------------------------------
+"""Headless plugin manifest.
+
+"""
+import time
+import os
+import json
+
+from enaml.workbench.api import PluginManifest, Extension
+from enaml.workbench.ui.api import ActionItem
+from enaml.workbench.core.api import Command
+
+from ...measurement.measurement import Measurement
+from ..api import AppStartup
+from ...measurement.hooks.api import PostExecutionHook
+
+from ..headless.autoclose import AutoClose
+
+PLUGIN_ID ='exopy.app.headless'
+
+
+# =============================================================================
+# --- Factories ---------------------------------------------------------------
+# =============================================================================
+
+def log_plugin_factory():
+    """ Factory function for the LogPlugin.
+
+    """
+    from .plugin import LogPlugin
+    return LogPlugin()
+
+
+# =============================================================================
+# --- Startup handler ---------------------------------------------------------
+# =============================================================================
+
+def start_headless_measurement(workbench, cmd_args):
+    """Start headless measurement system.
+
+    """
+    path = cmd_args.execute
+    if path:
+        meas_plugin = workbench.get_plugin('exopy.measurement')
+        meas, errors = Measurement.load(meas_plugin, path)
+        meas.add_tool('post-hook', 'exopy.autoclose')
+        meas_plugin.processor.continuous_processing = False
+        meas_plugin.processor.start_measurement(meas)
+        # time.sleep(5)
+        # while meas_plugin.processor.active:
+        #     time.sleep(0.05)
+        # print("Done!")
+
+# =============================================================================
+# --- Descriptions ------------------------------------------------------------
+# =============================================================================
+
+
+
+# =============================================================================
+# --- Manifest ----------------------------------------------------------------
+# =============================================================================
+
+enamldef HeadlessManifest(PluginManifest):
+    """Manifest for the plugin handling logging for an application.
+
+    """
+    id = PLUGIN_ID
+    factory = log_plugin_factory
+
+    # =========================================================================
+    # --- Extensions ----------------------------------------------------------
+    # =========================================================================
+    Extension:
+        id = 'startup'
+        point = 'exopy.app.startup'
+        AppStartup:
+            id = 'exopy.app.headless'
+            priority = 1
+            run => (workbench, cmd_args):
+                start_headless_measurement(workbench, cmd_args)
+    Extension:
+        id = 'post-execution'
+        point = 'exopy.measurement.post-execution'
+        PostExecutionHook:
+            id = 'exopy.autoclose'
+            description = 'Closes Exopy at the end of the measurement.'
+            new => (workbench, defaults=True):
+                return AutoClose()

--- a/exopy/app/headless/manifest.enaml
+++ b/exopy/app/headless/manifest.enaml
@@ -50,13 +50,10 @@ def start_headless_measurement(workbench, cmd_args):
     if path:
         meas_plugin = workbench.get_plugin('exopy.measurement')
         meas, errors = Measurement.load(meas_plugin, path)
-        meas.add_tool('post-hook', 'exopy.autoclose')
+        if errors:
+            print(errors)
         meas_plugin.processor.continuous_processing = False
-        meas_plugin.processor.start_measurement(meas)
-        # time.sleep(5)
-        # while meas_plugin.processor.active:
-        #     time.sleep(0.05)
-        # print("Done!")
+        meas_plugin.processor._run_measurement(meas, headless=True)
 
 # =============================================================================
 # --- Descriptions ------------------------------------------------------------

--- a/exopy/measurement/processor.py
+++ b/exopy/measurement/processor.py
@@ -76,6 +76,7 @@ class MeasurementProcessor(Atom):
         """Start a new measurement.
 
         """
+        print("measurement started")
         if self._thread and self._thread.is_alive():
             self._state.set('stop_processing')
             self._thread.join(5)
@@ -265,10 +266,15 @@ class MeasurementProcessor(Atom):
         self._state.clear('processing')
         deferred_call(setattr, self, 'active', False)
 
-    def _run_measurement(self, measurement):
+    def _run_measurement(self, measurement, headless=False):
         """Run a single measurement.
 
         """
+        plugin = self.plugin
+        if not self.engine:
+            engine = plugin.create('engine', plugin.selected_engine)
+            self.engine = engine
+
         # Switch to running state.
         measurement.enter_running_state()
 
@@ -311,10 +317,11 @@ class MeasurementProcessor(Atom):
         errors = {}
         if self._check_for_pause_or_stop():
 
-            # Connect new monitors, and start them.
-            logger.debug('Connecting monitors for measurement %s',
-                         meas_id)
-            self._start_monitors(measurement)
+            if not headless:
+                # Connect new monitors, and start them.
+                logger.debug('Connecting monitors for measurement %s',
+                             meas_id)
+                self._start_monitors(measurement)
 
             # Assemble the task infos for the engine to run the main task.
             deps = measurement.dependencies
@@ -340,10 +347,11 @@ class MeasurementProcessor(Atom):
             errors.update(execution_result.errors)
             measurement.task_execution_result = execution_result
 
-            # Disconnect monitors.
-            logger.debug('Disonnecting monitors for measurement %s',
-                         meas_id)
-            self._stop_monitors(measurement)
+            if not headless:
+                # Disconnect monitors.
+                logger.debug('Disonnecting monitors for measurement %s',
+                             meas_id)
+                self._stop_monitors(measurement)
 
         # Save the stop_attempt state to allow to run post execution if we
         # are supposed to do so.


### PR DESCRIPTION
This patch add a headless mode to exopy. When exopy is launched with an `-x` option and a filename, exopy runs the measurement and exits immediately. The GUI is never displayed.
This patch was developed by Bastien Voirin and I to enable a new calibration framework: [qualib](https://github.com/bastienvoirin/qualib).